### PR TITLE
test case: 'let' with a comment

### DIFF
--- a/test/Main.purs
+++ b/test/Main.purs
@@ -41,6 +41,7 @@ main = launchAff_ do
     , "test/fetch-github.nix"
     , "test/list.nix"
     , "test/nixpkgs-mozilla.nix"
+    , "test/let-with-comment.nix"
     ]
   let output = Array.intercalate "\n\n" results
   writeTextFile UTF8 "test/output.nix" output

--- a/test/let-with-comment.nix
+++ b/test/let-with-comment.nix
@@ -1,0 +1,9 @@
+let
+  nixpkgs = import <nixpkgs>;
+  # some comment
+in
+with nixpkgs;
+  stdenv.mkDerivation {
+    name = "something";
+    buildInputs = [];
+  }

--- a/test/output.nix
+++ b/test/output.nix
@@ -142,3 +142,30 @@ import (pkgs.fetchFromGitHub {
 
   b = [ 1 2 3 4 5 ];
 }
+
+
+(expression (let (binds (bind (attrpath (identifier)) (app (identifier) (quantity (app (select (identifier) (attrpath (identifier))) (uri))))) (bind (attrpath (identifier)) (app (app (identifier) (spath)) (attrset (bind (attrpath (identifier)) (list (identifier))))))) (with (identifier) (app (select (identifier) (attrpath (identifier))) (attrset (bind (attrpath (identifier)) (string)) (bind (attrpath (identifier)) (list (select (identifier) (attrpath (identifier) (identifier) (identifier) (identifier))))))))))
+let
+  moz_overlay = import (builtins.fetchTarball https://github.com/mozilla/nixpkgs-mozilla/archive/master.tar.gz);
+
+  nixpkgs = import <nixpkgs> {
+    overlays = [ moz_overlay ];
+  };
+
+in with nixpkgs; stdenv.mkDerivation {
+  name = "moz_overlay_shell";
+
+  buildInputs = [ nixpkgs.latest.rustChannels.nightly.rust ];
+}
+
+
+(expression (let (binds (bind (attrpath (identifier)) (app (identifier) (spath)))) (comment) (with (identifier) (app (select (identifier) (attrpath (identifier))) (attrset (bind (attrpath (identifier)) (string)) (bind (attrpath (identifier)) (list)))))))
+let
+  nixpkgs = import <nixpkgs>;
+  # some comment
+
+in with nixpkgs; stdenv.mkDerivation {
+  name = "something";
+
+  buildInputs = [ ];
+}


### PR DESCRIPTION
The problem seems to go away if the comment is removed.

output

```nix
Unknown let variation let
  nixpkgs = import <nixpkgs>;
  # some comment
in
with nixpkgs;
  stdenv.mkDerivation {
    name = "something";
    buildInputs = [];
  }
```