### PR TITLE
travis: use pkgs.nodePackages.pulp instead of npm

### DIFF
--- a/travis.nix
+++ b/travis.nix
@@ -14,9 +14,10 @@ let
 in pkgs.stdenv.mkDerivation {
   name = "travis-shell";
 
-  buildInputs = [ pkgs.nodejs easy-ps.psc-package-simple easy-ps.purs ];
-
-  shellHook = ''
-    npm i pulp
-  '';
+  buildInputs = [
+    pkgs.nodejs
+    pkgs.nodePackages.pulp
+    easy-ps.psc-package-simple
+    easy-ps.purs
+  ];
 }


### PR DESCRIPTION
I think this should work. I'm using both Nix stable and unstable and I think `pkgs.nodePackages.pulp` is available on stable. But it's not listed on https://nixos.org/nixos/packages.html